### PR TITLE
fix host_del

### DIFF
--- a/ipahttp/ipahttp.py
+++ b/ipahttp/ipahttp.py
@@ -165,7 +165,7 @@ class ipa(object):
         return results
 
     def host_del(self, hostname):
-        m = {'item': [hostname], 'method': 'host_del', 'params': {'all': True}}
+        m = {'item': [hostname], 'method': 'host_del', 'params': {'version': '2.164'}}
         results = self.makeReq(m)
 
         return results


### PR DESCRIPTION
Previously produces this error:
```python
'error': {'code': 3005,
  'message': 'Unknown option: all',
  'name': 'OptionError'}
```

Works without `all` option. Also added explicit version (same version seen elsewhere in this library).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nordnet/python-freeipa-json/10)
<!-- Reviewable:end -->
